### PR TITLE
Add support for epoch-end metrics calculation in Trainer.

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -103,7 +103,17 @@ class TestTrainer(unittest.TestCase):
             self.trainer.run(n_epoch=test_epoch, loader=self.loader)
 
     def test_single_epoch_run(self):
-        self.trainer.run(n_epoch=1, loader=self.loader)
+        self.trainer.metric_on_epoch_end = lambda: {"asd": 1}
+        self.trainer.run_epoch(loader=self.loader)
+        # test metrics
+        print(f"Train metrics: {self.trainer.train_metrics}")
+        print(f"Valid metrics: {self.trainer.test_metrics}")
+        self.assertTrue(self.trainer.train_metrics)  # Check train metrics exist
+        self.assertFalse(self.trainer.test_metrics)  # Valid metrics should be empty in this case
+
+        self.trainer.run_epoch(loader=self.loader)
+        self.trainer.mode = "test"
+        self.trainer.run_epoch(loader=self.loader)
         # test metrics
         print(f"Train metrics: {self.trainer.train_metrics}")
         print(f"Valid metrics: {self.trainer.test_metrics}")

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -81,18 +81,17 @@ class TestTrainer(unittest.TestCase):
             self.assertEqual(id(dummy_sample), id(dummy_in_cpu))
 
     def test_run(self):
+        self.trainer.toggle("train")
+        self.trainer.metric_on_epoch_end = lambda: {"asd": 1}
         self.trainer.run(n_epoch=randint(1, 4), loader=self.loader)
         # test _check_batch_size
         self.assertEqual(self.trainer.batch_size, self.trainer.loader.batch_size)
         self.assertEqual(self.trainer.valid_batch_size, 0)
-        # test _scheduler_step_check
-        pass
+
         # test logging
-        log_a, log_b = self.trainer.log_train, self.trainer.log_test
-        if self.trainer.mode == "test":
-            log_a, log_b = log_b, log_a
-        self.assertEqual(len(self.loader), len(log_a["loss"]))
-        self.assertEqual(0, len(log_b["loss"]))
+        self.assertTrue(self.trainer.train_metrics)  # Check that metrics were computed
+        self.assertEqual(len(self.loader), len(self.trainer.log_train["loss"]))
+        self.assertEqual(0, len(self.trainer.log_test["loss"]))
 
         # test batch step
         self.trainer.scheduler_step_on_batch = True
@@ -104,18 +103,12 @@ class TestTrainer(unittest.TestCase):
             self.trainer.run(n_epoch=test_epoch, loader=self.loader)
 
     def test_single_epoch_run(self):
-        # TODO
-        # FAILED tests/trainer/test_trainer.py::TestTrainer::test_single_epoch_run - AssertionError: 0 != 1
         self.trainer.run(n_epoch=1, loader=self.loader)
-        # test logging
-        log_a, log_b = self.trainer.log_train, self.trainer.log_test
-        print(f"Tested in {self.trainer.mode} mode.")
-        print(f"Length of log_a: {len(log_a)}")
-        print(f"Length of log_a: {len(log_b)}")
-        if self.trainer.mode == "test":
-            log_a, log_b = log_b, log_a
-
-        self.assertEqual(max(len(log_a), len(log_b)), 1)
+        # test metrics
+        print(f"Train metrics: {self.trainer.train_metrics}")
+        print(f"Valid metrics: {self.trainer.test_metrics}")
+        self.assertTrue(self.trainer.train_metrics)  # Check train metrics exist
+        self.assertTrue(self.trainer.test_metrics)  # Valid metrics should be empty in this case
 
     def test_steps(self):
         dummy_sample = [randint(0, 128)] * randint(0, 128)
@@ -149,13 +142,11 @@ class TestTrainer(unittest.TestCase):
         self.assertGreater(post_buffer, pre_buffer)
 
     def test_log_reset(self):
-        # TODO
-        # FAILED tests/trainer/test_trainer.py::TestTrainer::test_log_reset - AssertionError: [] == []
         self.trainer.log_reset()
         self.assertFalse(self.trainer.log_train)
         self.assertFalse(self.trainer.log_test)
-        self.assertNotEqual(self.trainer.get_loss_history("train"), [])
-        self.assertNotEqual(self.trainer.get_loss_history("test"), [])
+        self.assertFalse(self.trainer.train_metrics)  # Ensure train metrics are reset
+        self.assertFalse(self.trainer.test_metrics)  # Ensure valid metrics are reset
 
     def test_print_log(self):
         c_batch, n_batch = randint(0, 16), randint(0, 16)

--- a/zae_engine/trainer/README_trainer-ko.md
+++ b/zae_engine/trainer/README_trainer-ko.md
@@ -1,86 +1,91 @@
-아래와 같이 Trainer 서브패키지의 README에 "MPU Addon" 섹션을 추가하여 advanced 용도로 사용할 수 있는 내용을 포함했습니다. 또한 "MPU Addon"을 명확하게 설명하고, README 구조에 맞게 advanced 섹션으로 편입시켰습니다. 
+# Trainer 서브패키지 개요
+
+**zae-engine** 라이브러리의 Trainer 서브패키지는 딥러닝 모델 학습을 관리하고 다양한 애드온을 통해 기능을 확장할 수 있는 강력한 도구를 제공합니다. `Trainer` 클래스는 학습 프로세스를 감독하는 핵심 구성 요소로, 사용자 정의 학습 및 테스트 단계를 구현할 수 있는 추상 메서드를 제공합니다. 애드온 시스템을 통해 사용자는 학습 워크플로우를 쉽게 확장하고 사용자화할 수 있습니다.
+
+## 주요 클래스 및 기능
+
+### Trainer
+
+`Trainer`는 모델의 학습 루틴을 관리하기 위해 설계된 추상 기본 클래스입니다. 사용자는 이를 상속받아 학습(`train_step`)과 테스트(`test_step`) 중 수행할 동작을 정의해야 합니다.
+
+#### 주요 속성
+- **model**: 학습할 모델(`torch.nn.Module`).
+- **device**: 모델 학습을 위한 디바이스(예: 'cuda' 또는 ['cuda:0', 'cuda:1']).
+- **optimizer**: 학습에 사용되는 옵티마이저(`torch.optim.Optimizer`).
+- **scheduler**: 학습률 스케줄러(`torch.optim.lr_scheduler._LRScheduler`).
+- **log_bar**: 학습 중 진행 바를 표시할지 여부.
+- **gradient_clip**: 그래디언트 클리핑 값(기본값: 0.0).
+- **log_train & log_test**: 각 epoch 동안 학습 및 검증 데이터를 기록하는 사전 형태의 로그.
+
+#### 주요 기능
+- **디바이스 관리**: 모델과 데이터를 적절한 디바이스에 할당하여 단일 GPU 및 다중 GPU 학습을 지원합니다.
+- **배치 처리**: 학습 또는 테스트 모드에서 각 배치를 처리하며, 학습 모드에서는 역전파도 수행합니다.
+- **로그 관리**: 각 epoch 또는 배치에서 손실 및 기타 메트릭 정보를 수집하고, 로그를 저장하거나 출력할 수 있습니다.
+- **그래디언트 클리핑**: 학습 중 그래디언트 폭발을 방지하기 위해 그래디언트를 선택적으로 클리핑할 수 있습니다.
+- **스케줄러 통합**: 학습률 스케줄러를 epoch 또는 배치 수준에서 적용하여 학습 과정을 적응적으로 제어합니다.
+- **상태 저장 및 불러오기**: 모델 가중치를 저장하고 저장된 가중치를 불러와 추론 또는 학습을 이어갈 수 있습니다.
+
+#### 주요 메서드
+- **train_step(batch)**: 각 학습 단계에서 수행할 동작 정의.
+- **test_step(batch)**: 각 테스트 단계에서 수행할 동작 정의.
+- **run(n_epoch, loader, valid_loader)**: 지정된 epoch 수만큼 학습 또는 테스트 실행.
+- **run_epoch(loader)**: 단일 epoch 동안 학습 또는 테스트 실행.
+- **run_batch(batch)**: 단일 배치에 대한 학습 또는 테스트 실행.
+- **add_on(*add_on_cls)**: 애드온을 통해 `Trainer` 클래스의 기능 확장.
+- **metric_on_epoch_end()**: 각 epoch 종료 시 사용자 정의 메트릭을 정의하고 `log_train` 및 `log_test`를 활용할 수 있음.
+
+### ProgressChecker
+
+`ProgressChecker`는 학습 또는 테스트 진행 상황을 추적하는 도우미 클래스입니다. epoch 및 단계 수를 관리하여 사용자가 학습 상태를 쉽게 모니터링할 수 있도록 합니다.
 
 ---
 
-# Trainer 서브패키지 개요
+## 애드온 기능
 
-**zae-engine** 라이브러리의 Trainer 서브패키지는 딥러닝 모델 학습을 위한 유연하고 강력한 프레임워크를 제공합니다. 이 서브패키지의 핵심 구성 요소는 `Trainer` 클래스이며, 사용자가 맞춤형 학습 프로세스를 구현할 수 있도록 도와줍니다. 또한 다양한 애드온을 통해 기능을 확장하여 학습 프로세스를 더욱 향상시킬 수 있습니다. 이 README는 Trainer 서브패키지의 주요 기능과 사용 가능한 애드온을 설명합니다.
+Trainer 서브패키지는 `AddOnBase` 클래스를 통해 분산 학습, 상태 관리 및 웹 로깅과 같은 기능을 확장할 수 있습니다.
 
-### 주요 구성 요소
+### 주요 애드온
 
-- **Trainer**: `Trainer`는 학습과 테스트 프로세스를 관리하는 추상 클래스입니다. 사용자는 `Trainer`를 상속받아 `train_step()`과 `test_step()` 메서드를 구현해야 합니다. 이 메서드들은 각각 학습과 테스트 시의 동작을 정의합니다.
+#### StateManagerAddon
+모델 상태, 옵티마이저 상태 및 스케줄러 상태를 저장하고 불러오는 기능을 제공합니다. `.ckpt` 및 `.safetensor` 형식을 지원하여 보안성과 유연성을 제공합니다.
 
-  주요 기능:
-  - **디바이스 관리**: 모델과 데이터를 적절한 디바이스에 할당하여 단일 GPU 및 다중 GPU 학습을 지원합니다.
-  - **배치 처리**: 학습 또는 테스트 모드에서 각 배치를 처리하며, 학습 모드에서는 역전파도 수행합니다.
-  - **로그 관리**: 각 epoch 또는 배치에서 손실 및 기타 메트릭 정보를 수집하고, 로그를 저장하거나 출력할 수 있습니다.
-  - **그래디언트 클리핑**: 학습 중 그래디언트 폭발을 방지하기 위해 그래디언트를 선택적으로 클리핑할 수 있습니다.
-  - **스케줄러 통합**: 학습률 스케줄러를 epoch 또는 배치 수준에서 적용하여 학습 과정을 적응적으로 제어합니다.
-  - **상태 저장 및 불러오기**: 모델 가중치를 저장하고 저장된 가중치를 불러와 추론 또는 학습을 이어갈 수 있습니다.
+#### MultiGPUAddon
+DDP(Distributed Data Parallel)를 사용하여 여러 GPU에서 분산 학습을 지원합니다. PyTorch의 분산 학습 유틸리티와 통합되어 대규모 모델의 학습 속도를 크게 향상시킬 수 있습니다.
 
-- **애드온 시스템**: `Trainer` 클래스는 애드온을 통해 추가 기능을 확장할 수 있습니다. `Trainer.add_on()` 메서드를 사용하여 원하는 애드온 클래스를 전달하면 기능을 추가할 수 있습니다.
+#### WandBLoggerAddon / NeptuneLoggerAddon
+Weights & Biases(WandB) 또는 Neptune과 같은 외부 서비스를 사용하여 학습 프로세스를 실시간으로 모니터링할 수 있습니다. 학습 메트릭을 자동으로 로깅하며, 사용자는 원격으로 진행 상황을 추적할 수 있습니다.
 
-### 사용 가능한 애드온
+---
 
-1. **StateManagerAddon**
-   - 모델, 옵티마이저, 스케줄러의 상태를 저장하고 불러오는 기능을 제공합니다. `.ckpt` 또는 `.safetensor` 형식으로 상태를 저장할 수 있어 저장과 보안에서 유연성을 제공합니다.
+## 사용 예제
 
-2. **WandBLoggerAddon & NeptuneLoggerAddon**
-   - Weights and Biases (WandB) 또는 Neptune과 같은 외부 서비스에 학습 메트릭을 기록할 수 있습니다. 사용자는 학습 진행 상황을 원격으로 모니터링하고, 메트릭을 추적하며, 모델 성능을 시각화할 수 있습니다.
+### 기본 사용법
 
-3. **MultiGPUAddon**
-   - PyTorch의 분산 학습 유틸리티를 사용하여 여러 GPU에서 모델을 학습할 수 있도록 지원합니다. 각 GPU에 대한 프로세스를 생성하고 `DistributedDataParallel (DDP)`를 사용해 모델 업데이트를 동기화합니다. 대규모 모델의 학습 시간을 단축하는 데 유용합니다.
+```python
+from zae_engine.trainer import Trainer
+from zae_engine.trainer.addons import StateManagerAddon, WandBLoggerAddon
 
-### Trainer 사용 방법
+# StateManager 및 WandBLogger 애드온 추가
+MyTrainer = Trainer.add_on(StateManagerAddon, WandBLoggerAddon)
 
-1. **커스텀 Trainer 생성**: `Trainer`를 상속받아 `train_step()`과 `test_step()` 메서드를 구현합니다. 각 메서드는 학습과 테스트 중 각 배치에서 수행할 동작을 정의합니다.
-   
-   ```python
-   from zae_engine.trainer import Trainer
+trainer = MyTrainer(
+    model=my_model,
+    device='cuda',
+    mode='train',
+    optimizer=my_optimizer,
+    scheduler=my_scheduler,
+    save_path='./checkpoints',
+    web_logger={"wandb": {"project": "my_project"}},
+)
 
-   class MyTrainer(Trainer):
-       def train_step(self, batch):
-           x, y = batch['input'], batch['target']
-           outputs = self.model(x)
-           loss = self.criterion(outputs, y)
-           return {'loss': loss}
+trainer.run(n_epoch=10, loader=train_loader, valid_loader=valid_loader)
+```
 
-       def test_step(self, batch):
-           x, y = batch['input'], batch['target']
-           outputs = self.model(x)
-           loss = self.criterion(outputs, y)
-           return {'loss': loss}
-   ```
+### 고급 기능: MultiGPUAddon 사용
 
-2. **애드온 통합**: Trainer를 확장해야 할 경우, `add_on()` 메서드를 사용합니다.
-   
-   ```python
-   from zae_engine.trainer.addons import StateManagerAddon, WandBLoggerAddon
+`MultiGPUAddon`은 여러 GPU에서 모델을 병렬로 학습시킬 수 있는 강력한 도구입니다. 이 애드온은 PyTorch의 DDP(Distributed Data Parallel)를 활용하여 모든 GPU에서 모델과 데이터를 올바르게 동기화합니다.
 
-   CustomTrainer = MyTrainer.add_on(StateManagerAddon, WandBLoggerAddon)
-   trainer = CustomTrainer(
-       model=my_model,
-       device='cuda',
-       mode='train',
-       optimizer=my_optimizer,
-       scheduler=my_scheduler,
-       save_path='./model_states'
-   )
-   ```
-
-3. **학습 실행**: `trainer.run()`을 호출하여 학습을 시작합니다.
-
-   ```python
-   trainer.run(n_epoch=50, loader=train_loader, valid_loader=valid_loader)
-   ```
-
-### Advanced: MultiGPUAddon 사용하기
-
-`MultiGPUAddon`은 여러 GPU에서 학습을 병렬로 수행할 수 있도록 하는 강력한 애드온입니다. 이 애드온을 사용하면 PyTorch의 분산 데이터 병렬 처리(DistributedDataParallel, DDP)를 활용하여 대규모 모델의 학습 시간을 대폭 단축할 수 있습니다.
-
-#### MultiGPUAddon 사용 예제
-
-아래는 `MultiGPUAddon`을 사용하여 여러 GPU에서 모델을 학습하는 방법을 보여줍니다.
+#### MultiGPUAddon을 활용한 학습 예제
 
 ```python
 import os
@@ -124,12 +129,12 @@ def main():
     dataset = DummyDataset(1000)
     train_loader = DataLoader(dataset, batch_size=32, shuffle=True)
 
-    # 모델, 옵티마이저, 스케줄러 설정
+    # 모델, 옵티마이저 및 스케줄러 설정
     model = nn.Linear(10, 2)
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     scheduler = CosineAnnealingScheduler(optimizer=optimizer, total_iters=100)
 
-    # Trainer 인스턴스 생성 & 학습
+    # Trainer 인스턴스 생성 및 학습 실행
     trainer = MultiGPUTrainer(
         model=model,
         device=device_list,
@@ -147,18 +152,18 @@ if __name__ == "__main__":
     main()
 ```
 
-#### 설명
-- **DummyDataset**: [0, 1] 범위의 임의 데이터와 레이블을 생성합니다.
-- **DummyModel**: 이진 분류를 위한 간단한 단일 선형 레이어를 가진 신경망을 준비합니다.
-- **MultiGPUTrainer**: 순전파 및 역전파, 손실 계산과 모델 최적화를 포함하는 사용자 정의 트레이너 클래스입니다.
-- **MultiGPUAddon**: 이 애드온을 통해 Trainer 클래스는 여러 GPU를 사용하여 병렬 학습을 수행할 수 있습니다.
-- **학습 프로세스**: `Trainer.run` 메소드를 사용하여 지정된 epoch 수만큼 모델을 학습시킵니다. 학습 후 모델은 파일(`dummy_model_mgpu.pth`)로 저장됩니다.
+---
 
-#### 참고 사항
-- `MultiGPUAddon`을 사용하려면 시스템에 CUDA 호환 GPU가 2개 이상 있어야 합니다.
-- 이 예제는 PyTorch의 `DistributedDataParallel`을 활용하여 각 GPU에서 데이터를 병렬로 처리하고 모델을 학습시킵니다.
-- `init_method`는 네트워크 상에서 프로세스 간 통신을 설정하는 방법을 지정합니다. 이 예제에서는 `localhost`를 사용하고 있습니다.
+### FAQ 및 일반적인 문제
 
-### 요약
+- **Q: `init_method`에서 'Address already in use' 오류가 발생하면 어떻게 하나요?**
+  **A**: `init_method`에 지정된 포트(예: `12355`)가 이미 사용 중인지 확인하세요. 포트 번호를 변경하거나 `os.environ["MASTER_PORT"]`를 사용하여 동적으로 설정하세요.
 
-Trainer 서브패키지는 머신 러닝 모델 학습을 위한 적응적이고 확장 가능한 기반을 제공합니다. 추상 메서드와 애드온을 통해 사용자에게 학습 프로세스를 제어할 수 있는 유연성을 제공하며, 다중 GPU 지원 및 외부 로깅 서비스 통합과 같은 다양한 내장 기능을 제공합니다. 특히, `MultiGPUAddon`과 같은 고급 애드온은 대규모 모델의 학습을 더욱 빠르고 효율적으로 수행할 수 있도록 도와줍니다.
+- **Q: 여러 GPU를 사용할 때 학습 속도가 느려지는 이유는 무엇인가요?**
+  **A**: 배치 크기가 충분히 큰지 확인하세요. DDP는 작업이 GPU 간에 균등하게 분배될 때 가장 잘 작동합니다. 데이터 로딩이 최적화되었는지도 확인하세요.
+
+- **Q: 사용자 정의 메트릭을 추가하려면 어떻게 해야 하나요?**
+  **A**: Trainer 서브클래스에서 `metric_on_epoch_end()` 메서드를 재정의하고 사용자 정의 메트릭 딕셔너리를 반환하세요.
+
+---
+

--- a/zae_engine/trainer/_trainer.py
+++ b/zae_engine/trainer/_trainer.py
@@ -38,6 +38,14 @@ class Trainer(ABC):
         Whether to update the scheduler on each batch, by default False.
     gradient_clip : float, optional
         Gradient clipping value. If 0, no gradient clipping is applied, by default 0.0.
+
+    Notes
+    -----
+    - The `metric_on_epoch_end` method is provided for calculating and logging custom metrics
+      at the end of each epoch. It should be overridden by subclasses if custom metrics are needed.
+    - The method `metric_on_epoch_end` is expected to return a dictionary where keys are metric
+      names and values are the corresponding computed values. These metrics will be displayed in
+      the progress bar if `log_bar` is enabled.
     """
 
     def __init__(
@@ -360,10 +368,33 @@ class Trainer(ABC):
         """
         A method that can be overridden by users to calculate custom metrics at the end of an epoch.
 
+        This method is designed to be flexible and user-extendable. By default, it does nothing
+        and returns None. Subclasses can override this method to compute any custom metrics
+        based on the results of the epoch.
+
         Returns
         -------
         Optional[Dict[str, float]]:
-            A dictionary containing computed metric values as key-value pairs. Returns None by default.
+            A dictionary containing computed metric values as key-value pairs. The keys represent
+            metric names, and the values are their corresponding values. Returns None by default.
+
+        Notes
+        -----
+        - This method is called automatically at the end of each epoch if `log_bar` is enabled.
+        - The results returned by this method are appended to the progress bar description during
+          training/testing.
+
+        Examples
+        --------
+        To compute a validation accuracy metric:
+
+        >>> class CustomTrainer(Trainer):
+        >>>     def metric_on_epoch_end(self) -> Optional[Dict[str, float]]:
+        >>>         # Assume 'output' and 'label' keys exist in log_test
+        >>>         outputs = torch.cat(self.log_test["output"], dim=0)  # Combine outputs from all batches
+        >>>         labels = torch.cat(self.log_test["label"], dim=0)    # Combine labels from all batches
+        >>>         accuracy = (outputs.argmax(dim=1) == labels).float().mean().item()
+        >>>         return {"val_accuracy": accuracy}
         """
         return None
 

--- a/zae_engine/trainer/_trainer.py
+++ b/zae_engine/trainer/_trainer.py
@@ -268,7 +268,7 @@ class Trainer(ABC):
         progress = tqdm.tqdm(loader, position=1, leave=False) if self.log_bar else loader
         for i, batch in enumerate(progress):
             self.run_batch(batch, **kwargs)
-            self._data_count()
+            self._data_count(True if self.batch_size is None else False)
             desc, printer = self.print_log(cur_batch=i + 1, num_batch=len(loader))
             if self.log_bar:
                 progress.set_description(desc)
@@ -462,14 +462,15 @@ class Trainer(ABC):
         self.loss_buffer = cur_loss
         return True
 
-    def log_reset(self) -> None:
+    def log_reset(self, epoch_end: bool = False) -> None:
         """
         Clear the log.
         """
         self.log_train.clear()
         self.log_test.clear()
-        self.train_metrics.clear()
-        self.test_metrics.clear()
+        if epoch_end:
+            self.train_metrics.clear()
+            self.test_metrics.clear()
 
     def get_loss_history(self, mode: str = "train") -> list:
         """


### PR DESCRIPTION
[Key Changes]

#### 1. metric_on_epoch_end Method:
- A user-overridable method that calculates custom metrics at the end of an epoch.
- Automatically called within the `run_epoch` method, ensuring it has access to the accumulated data from `log_train` or `log_test`.

#### 2. Metrics State Management:
- Introduced `train_metrics` and `valid_metrics` attributes in `Trainer` to store epoch-end metrics for training and validation modes, respectively.
- These attributes are reset at the beginning of each epoch and updated after `metric_on_epoch_end` is called.

#### 3. Enhanced Logging:
- Epoch-end metrics are now displayed in the progress bar or logged after each epoch during training or validation.

#### 4. Backward Compatibility:
- Existing functionality for mini-batch logging (`log_train` and `log_test`) remains unaffected.
- No breaking changes have been introduced for users relying on mini-batch-level operations.

#### Example Usage
Users can override the `metric_on_epoch_end` method to compute custom metrics based on `log_train` or `log_test`. For example:

```python
class CustomTrainer(Trainer):
    def metric_on_epoch_end(self):
        outputs = torch.cat(self.log_train["output"], dim=0)
        labels = torch.cat(self.log_train["label"], dim=0)
        accuracy = (outputs.argmax(dim=1) == labels).float().mean().item()
        return {"accuracy": accuracy}
```

#### Testing and Validation
- Added unittests to verify:
    1. Metrics are correctly calculated and stored in `train_metrics` and `valid_metrics`.
    2. Logs and metrics are consistent with previous functionality.
    3. Backward compatibility for mini-batch-level logging.

#### Impact
This update enhances `Trainer` by enabling more comprehensive metric calculations over the entire dataset, which is particularly useful for metrics that require global statistics or context (e.g., accuracy, precision-recall).


!GPT