### PR TITLE
feat: Add PrecisionMixerAddon for mixed precision training

### DIFF
--- a/tests/trainer/addons/test_core.py
+++ b/tests/trainer/addons/test_core.py
@@ -1,5 +1,8 @@
 import unittest
 from typing import Type
+
+import torch
+
 from zae_engine.trainer import Trainer
 from zae_engine.trainer.addons.core import AddOnBase
 
@@ -30,7 +33,7 @@ class TestCore(unittest.TestCase):
         TrainerWithAddon = DummyTrainer.add_on(DummyAddon)
         trainer = TrainerWithAddon(
             model=None,
-            device="cpu",
+            device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"),
             mode="train",
             optimizer=None,
             scheduler=None,
@@ -58,7 +61,7 @@ class TestCore(unittest.TestCase):
         TrainerWithMultipleAddons = DummyTrainer.add_on(DummyAddon, AnotherDummyAddon)
         trainer = TrainerWithMultipleAddons(
             model=None,
-            device="cpu",
+            device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"),
             mode="train",
             optimizer=None,
             scheduler=None,

--- a/tests/trainer/addons/test_core.py
+++ b/tests/trainer/addons/test_core.py
@@ -1,0 +1,79 @@
+import unittest
+from typing import Type
+from zae_engine.trainer import Trainer
+from zae_engine.trainer.addons.core import AddOnBase
+
+
+# Define a dummy add-on for testing
+class DummyAddon(AddOnBase):
+    @classmethod
+    def apply(cls, base_cls: Type[Trainer]) -> Type[Trainer]:
+        class TrainerWithDummyAddon(base_cls):
+            def dummy_method(self):
+                return "Dummy method executed."
+
+        return TrainerWithDummyAddon
+
+
+# Define a dummy Trainer for testing
+class DummyTrainer(Trainer):
+    def train_step(self, batch):
+        return {"loss": 0.0}
+
+    def test_step(self, batch):
+        return {"loss": 0.0}
+
+
+class TestCore(unittest.TestCase):
+    def test_addon_integration(self):
+        """Test that an AddOnBase subclass can be integrated with the Trainer."""
+        TrainerWithAddon = DummyTrainer.add_on(DummyAddon)
+        trainer = TrainerWithAddon(
+            model=None,
+            device="cpu",
+            mode="train",
+            optimizer=None,
+            scheduler=None,
+        )
+        self.assertTrue(hasattr(trainer, "dummy_method"), "Add-on method not integrated.")
+        self.assertEqual(trainer.dummy_method(), "Dummy method executed.", "Add-on method did not execute correctly.")
+
+    def test_addon_abstract_method(self):
+        """Test that AddOnBase cannot be instantiated directly."""
+        with self.assertRaises(TypeError):
+            AddOnBase()  # Attempt to instantiate abstract class
+
+    def test_multiple_addons(self):
+        """Test that multiple AddOns can be applied to a Trainer."""
+
+        class AnotherDummyAddon(AddOnBase):
+            @classmethod
+            def apply(cls, base_cls: Type[Trainer]) -> Type[Trainer]:
+                class TrainerWithAnotherAddon(base_cls):
+                    def another_dummy_method(self):
+                        return "Another dummy method executed."
+
+                return TrainerWithAnotherAddon
+
+        TrainerWithMultipleAddons = DummyTrainer.add_on(DummyAddon, AnotherDummyAddon)
+        trainer = TrainerWithMultipleAddons(
+            model=None,
+            device="cpu",
+            mode="train",
+            optimizer=None,
+            scheduler=None,
+        )
+        self.assertTrue(hasattr(trainer, "dummy_method"), "First add-on method not integrated.")
+        self.assertTrue(hasattr(trainer, "another_dummy_method"), "Second add-on method not integrated.")
+        self.assertEqual(
+            trainer.dummy_method(), "Dummy method executed.", "First add-on method did not execute correctly."
+        )
+        self.assertEqual(
+            trainer.another_dummy_method(),
+            "Another dummy method executed.",
+            "Second add-on method did not execute correctly.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/trainer/addons/test_mix_precision.py
+++ b/tests/trainer/addons/test_mix_precision.py
@@ -65,10 +65,12 @@ class TestPrecisionMixerAddon(unittest.TestCase):
 
     def test_fp32_precision(self):
         """Test FP32 precision with a GPU or CPU."""
+        if not torch.cuda.is_available():
+            self.skipTest("FP32 precision test skipped because no GPU is available.")
         trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
         trainer = trainer_cls(
             model=self.model,
-            device=self.device,
+            device=torch.device("cuda:0"),
             mode="train",
             optimizer=self.optimizer,
             scheduler=self.scheduler,

--- a/tests/trainer/addons/test_mix_precision.py
+++ b/tests/trainer/addons/test_mix_precision.py
@@ -1,0 +1,123 @@
+import unittest
+from typing import Union, Dict
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from zae_engine.trainer import Trainer
+from zae_engine.trainer.addons import PrecisionMixerAddon
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super(SimpleModel, self).__init__()
+        self.linear = nn.Linear(10, 2)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class CustomTrainer(Trainer):
+    def train_step(self, batch: Union[tuple, dict]) -> Dict[str, torch.Tensor]:
+        x, y = batch
+        outputs = self.model(x)
+        loss = nn.functional.cross_entropy(outputs, y)
+        return {"loss": loss}
+
+    def test_step(self, batch: Union[tuple, dict]) -> Dict[str, torch.Tensor]:
+        x, y = batch
+        outputs = self.model(x)
+        loss = nn.functional.cross_entropy(outputs, y)
+        return {"loss": loss}
+
+
+class TestPrecisionMixerAddon(unittest.TestCase):
+    def setUp(self):
+        self.model = SimpleModel()
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        self.optimizer = optim.SGD(self.model.parameters(), lr=0.01)
+        self.scheduler = optim.lr_scheduler.StepLR(self.optimizer, step_size=1, gamma=0.1)
+
+        # Generate some random data
+        data = torch.randn(100, 10)
+        labels = torch.randint(0, 2, (100,))
+        dataset = TensorDataset(data, labels)
+        self.loader = DataLoader(dataset, batch_size=10, shuffle=True)
+
+    def test_fp32_precision(self):
+        trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
+        trainer = trainer_cls(
+            model=self.model,
+            device=self.device,
+            mode="train",
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            precision="fp32",
+        )
+        trainer.run(n_epoch=1, loader=self.loader)
+        self.assertEqual(trainer.precision, ["fp32"])
+
+    def test_fp16_precision(self):
+        if not torch.cuda.is_available():
+            self.skipTest("FP16 requires a CUDA-enabled device.")
+        trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
+        trainer = trainer_cls(
+            model=self.model,
+            device=self.device,
+            mode="train",
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            precision="fp16",
+        )
+        trainer.run(n_epoch=1, loader=self.loader)
+        self.assertEqual(trainer.precision, ["fp16"])
+
+    def test_auto_precision(self):
+        trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
+        trainer = trainer_cls(
+            model=self.model,
+            device=self.device,
+            mode="train",
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            precision="auto",
+        )
+        expected_precision = (
+            ["bf16", "fp16"] if torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 8 else ["fp16"]
+        )
+        self.assertEqual(trainer.precision, expected_precision)
+
+    def test_grad_scaling_with_fp16(self):
+        if not torch.cuda.is_available():
+            self.skipTest("FP16 requires a CUDA-enabled device.")
+        trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
+        trainer = trainer_cls(
+            model=self.model,
+            device=self.device,
+            mode="train",
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            precision="fp16",
+        )
+        trainer.run(n_epoch=1, loader=self.loader)
+        self.assertIsNotNone(trainer.scaler, "GradScaler not initialized for FP16 precision.")
+
+    def test_run_batch(self):
+        trainer_cls = CustomTrainer.add_on(PrecisionMixerAddon)
+        trainer = trainer_cls(
+            model=self.model,
+            device=self.device,
+            mode="train",
+            optimizer=self.optimizer,
+            scheduler=self.scheduler,
+            precision="auto",
+        )
+        batch = next(iter(self.loader))
+        trainer.run_batch(batch)
+        self.assertTrue(hasattr(trainer, "log_train"), "Log not updated after running a batch.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zae_engine/trainer/_trainer.py
+++ b/zae_engine/trainer/_trainer.py
@@ -220,7 +220,9 @@ class Trainer(ABC):
         self._scheduler_step_check(n_epoch)
         pre_epoch = self.progress_checker.get_epoch() - 1
         progress = range(pre_epoch, total_epoch := (pre_epoch + n_epoch))
-        progress = tqdm.tqdm(progress, position=0, dynamic_ncols=True, file=sys.stderr, disable=not self.log_bar)
+        progress = tqdm.tqdm(
+            progress, position=0, dynamic_ncols=True, file=sys.stderr, leave=False, disable=not self.log_bar
+        )
 
         for e in progress:
             printer = progress.set_description if self.log_bar else print

--- a/zae_engine/trainer/addons/__init__.py
+++ b/zae_engine/trainer/addons/__init__.py
@@ -2,3 +2,4 @@ from .core import AddOnBase
 from .mpu import MultiGPUAddon
 from .web_logger import NeptuneLoggerAddon, WandBLoggerAddon
 from .state_manager import StateManagerAddon
+from .mix_precision import PrecisionMixerAddon

--- a/zae_engine/trainer/addons/mix_precision.py
+++ b/zae_engine/trainer/addons/mix_precision.py
@@ -1,0 +1,198 @@
+from typing import Type
+
+import torch
+from torch.cuda.amp import autocast, GradScaler
+
+from .core import AddOnBase
+from .._trainer import T
+
+
+class PrecisionMixerAddon(AddOnBase):
+    """
+    Add-on for mixed precision training.
+
+    This add-on enables mixed precision training to improve computational efficiency and reduce memory usage.
+    It supports automatic precision selection or user-defined precision settings (e.g., 'fp32', 'fp16', 'bf16').
+
+    Parameters
+    ----------
+    precision : Union[str, list], optional
+        The precision setting for training. Default is "auto".
+        - "auto": Automatically selects the best precision based on hardware capabilities.
+        - "fp32": Uses full precision (default in PyTorch).
+        - "fp16": Uses half precision for accelerated computation.
+        - "bf16": Uses Brain Float 16 precision for supported hardware.
+        - List: Specifies a priority order for precision (e.g., ["bf16", "fp16"]).
+
+    Methods
+    -------
+    run_batch(batch, **kwargs)
+        Override the batch processing method to apply mixed precision.
+
+    Notes
+    -----
+    - Mixed precision improves training speed and reduces memory usage by performing certain operations
+      in lower precision (e.g., FP16) while maintaining stability in others (e.g., FP32 for loss calculation).
+    - Automatically handles loss scaling via `torch.cuda.amp.GradScaler` to prevent overflow issues
+      when using FP16.
+
+    Examples
+    --------
+    Using PrecisionMixerAddon with auto precision:
+
+    >>> from zae_engine.trainer import Trainer
+    >>> from zae_engine.trainer.addons import PrecisionMixerAddon
+
+    >>> MyTrainer = Trainer.add_on(PrecisionMixerAddon)
+    >>> trainer = MyTrainer(
+    >>>     model=my_model,
+    >>>     device='cuda',
+    >>>     optimizer=my_optimizer,
+    >>>     scheduler=my_scheduler,
+    >>>     precision='auto'  # Automatically selects best precision
+    >>> )
+    >>> trainer.run(n_epoch=10, loader=train_loader, valid_loader=valid_loader)
+
+    Using a priority list for precision:
+
+    >>> trainer = MyTrainer(
+    >>>     model=my_model,
+    >>>     device='cuda',
+    >>>     optimizer=my_optimizer,
+    >>>     scheduler=my_scheduler,
+    >>>     precision=["bf16", "fp16"]  # Tries bf16 first, falls back to fp16
+    >>> )
+    >>> trainer.run(n_epoch=10, loader=train_loader)
+    """
+
+    @classmethod
+    def apply(cls, base_cls: Type[T]) -> Type[T]:
+        class PrecisionTrainer(base_cls):
+            def __init__(self, *args, precision: Union[str, list] = "auto", **kwargs):
+                super().__init__(*args, **kwargs)
+                self.precision = self._determine_precision(precision)
+                self.scaler = GradScaler() if "fp16" in self.precision else None
+
+            def _determine_precision(self, precision):
+                """
+                Determine the appropriate precision settings based on user input or hardware capabilities.
+
+                Parameters
+                ----------
+                precision : Union[str, list]
+                    The user-specified precision setting.
+                    - "auto": Automatically selects the best precision based on the GPU's hardware capabilities.
+                    - str: A single precision mode (e.g., "fp32", "fp16", "bf16").
+                    - list: A priority order for precision modes (e.g., ["bf16", "fp16"]).
+
+                Returns
+                -------
+                list
+                    A list of supported precision modes, ordered by priority.
+
+                Raises
+                ------
+                ValueError
+                    If the `precision` argument is not a valid string or list.
+
+                Notes
+                -----
+                - When "auto" is specified, the method checks the hardware's compute capability to determine
+                  the best available precision (e.g., "bf16" on NVIDIA Ampere GPUs, otherwise "fp16").
+                - If multiple precision modes are specified in a list, the method validates their compatibility
+                  with the hardware and prioritizes them as given.
+
+                Examples
+                --------
+                Automatically select the best precision:
+
+                >>> addon._determine_precision("auto")
+                ['bf16', 'fp16']
+
+                Use a specific precision:
+
+                >>> addon._determine_precision("fp32")
+                ['fp32']
+
+                Provide a priority list:
+
+                >>> addon._determine_precision(["bf16", "fp16"])
+                ['bf16', 'fp16']
+                """
+                if precision == "auto":
+                    # Select optimize precision.
+                    if torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 8:
+                        return ["bf16", "fp16"]  # Take BF16 first @ over `Ampere`
+                    elif torch.cuda.is_available():
+                        return ["fp16"]
+                    else:
+                        return ["fp32"]
+                elif isinstance(precision, str):
+                    return [precision]
+                elif isinstance(precision, list):
+                    return precision
+                else:
+                    raise ValueError("Invalid precision setting.")
+
+            def run_batch(self, batch, **kwargs):
+                """
+                Override the batch processing method to enable mixed precision training.
+
+                Parameters
+                ----------
+                batch : Union[tuple, dict]
+                    The batch of data to process.
+                kwargs : dict
+                    Additional arguments for batch processing.
+
+                Notes
+                -----
+                - If precision is set to "fp16" or "bf16", this method uses `torch.cuda.amp.autocast`
+                  to enable mixed precision operations for the forward pass.
+                - Loss scaling is automatically applied when using FP16 to prevent overflow issues.
+                - The precision setting does not affect the input data's original precision; it only
+                  applies during model computations and optimizer steps.
+
+                Examples
+                --------
+                Forward pass and gradient scaling with mixed precision:
+
+                >>> trainer.run_batch(batch)
+                >>> # AutoCast ensures model operations are performed in fp16 or bf16
+                """
+                batch = self._to_device(**batch) if isinstance(batch, dict) else self._to_device(*batch)
+
+                if self.mode == "train":
+                    self.model.train()
+                    self.optimizer.zero_grad()
+
+                    with autocast(enabled="fp16" in self.precision or "bf16" in self.precision, dtype=torch.float16):
+                        step_dict = self.train_step(batch)
+                        loss = step_dict["loss"]
+
+                    if self.scaler:
+                        self.scaler.scale(loss).backward()
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+                    else:
+                        loss.backward()
+                        self.optimizer.step()
+
+                    if self.scheduler_step_on_batch:
+                        self.scheduler.step(**kwargs)
+
+                elif self.mode == "test":
+                    self.model.eval()
+                    with torch.no_grad():
+                        with autocast(
+                            enabled="fp16" in self.precision or "bf16" in self.precision, dtype=torch.float16
+                        ):
+                            step_dict = self.test_step(batch)
+                else:
+                    raise ValueError(f"Unexpected mode {self.mode}.")
+
+                torch.cuda.synchronize()
+                self.logging(step_dict)
+                self.progress_checker.update_step()
+
+        return PrecisionTrainer

--- a/zae_engine/trainer/addons/mix_precision.py
+++ b/zae_engine/trainer/addons/mix_precision.py
@@ -70,6 +70,12 @@ class PrecisionMixerAddon(AddOnBase):
         class PrecisionTrainer(base_cls):
             def __init__(self, *args, precision: Union[str, list] = "auto", **kwargs):
                 super().__init__(*args, **kwargs)
+
+                # Check if all devices are CPU
+                if all("cpu" in str(device) for device in self.device):
+                    raise ValueError("PrecisionMixerAddon requires at least one GPU device to function.")
+
+                # Determine precision settings
                 self.precision = self._determine_precision(precision)
                 self.scaler = GradScaler() if "fp16" in self.precision else None
 
@@ -120,7 +126,6 @@ class PrecisionMixerAddon(AddOnBase):
                 ['bf16', 'fp16']
                 """
                 if precision == "auto":
-                    # Select optimize precision.
                     if torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] >= 8:
                         return ["bf16", "fp16"]  # Take BF16 first @ over `Ampere`
                     elif torch.cuda.is_available():


### PR DESCRIPTION
PrecisionMixerAddon has been added to support mixed precision training, enabling faster computations and reduced memory usage. It allows users to leverage mixed precision techniques (e.g., FP16, BF16) or stick to FP32 for stability.

### How to Use
1. Add PrecisionMixerAddon to your Trainer:
    ```python
    from zae_engine.trainer import Trainer
    from zae_engine.trainer.addons import PrecisionMixerAddon

    MyTrainer = Trainer.add_on(PrecisionMixerAddon)
    ```

2. Initialize the Trainer with desired precision settings:
    ```python
    trainer = MyTrainer(
        model=my_model,
        device='cuda',
        optimizer=my_optimizer,
        scheduler=my_scheduler,
        precision='auto'  # 'auto', 'fp32', 'fp16', 'bf16'
    )
    ```

3. Run your training as usual:
    ```python
    trainer.run(n_epoch=10, loader=train_loader, valid_loader=valid_loader)
    ```

### Key Features
- Automatically selects the best precision based on hardware (`precision='auto'`).
- Manual precision control with 'fp32', 'fp16', or 'bf16'.
- Includes support for GradScaler to ensure stability during FP16 training.
---
!GPT
resolved #157 